### PR TITLE
EAT-ify the ar4si claims-set

### DIFF
--- a/ar4si.go
+++ b/ar4si.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jws"
@@ -94,12 +93,12 @@ func (o *TrustTier) UnmarshalJSON(data []byte) error {
 // The AttestationResult is serialized to JSON and signed by the verifier using
 // JWT.
 type AttestationResult struct {
-	Status            *TrustTier   `json:"status"`
+	Status            *TrustTier   `json:"ear.status"`
 	Profile           *string      `json:"eat_profile"`
-	TrustVector       *TrustVector `json:"trust-vector,omitempty"`
-	RawEvidence       *[]byte      `json:"raw-evidence,omitempty"`
-	Timestamp         *time.Time   `json:"timestamp"` // TODO(tho) use "iat" instead?
-	AppraisalPolicyID *string      `json:"appraisal-policy-id,omitempty"`
+	TrustVector       *TrustVector `json:"ear.trustworthiness-vector,omitempty"`
+	RawEvidence       *[]byte      `json:"ear.raw-evidence,omitempty"`
+	IssuedAt          *int64       `json:"iat"`
+	AppraisalPolicyID *string      `json:"ear.appraisal-policy-id,omitempty"`
 	Extensions
 }
 
@@ -134,8 +133,8 @@ func (o AttestationResult) validate() error {
 		missing = append(missing, "'status'")
 	}
 
-	if o.Timestamp == nil {
-		missing = append(missing, "'timestamp'")
+	if o.IssuedAt == nil {
+		missing = append(missing, "'iat'")
 	}
 
 	if len(missing) == 0 && len(invalid) == 0 {

--- a/example_test.go
+++ b/example_test.go
@@ -11,7 +11,7 @@ func Example_encode_minimalist() {
 	ar := AttestationResult{
 		Status: &testStatus,
 
-		Timestamp:         &testTimestamp,
+		IssuedAt:          &testIAT,
 		AppraisalPolicyID: &testPolicyID,
 		Profile:           &testProfile,
 	}
@@ -21,7 +21,7 @@ func Example_encode_minimalist() {
 	fmt.Println(string(j))
 
 	// Output:
-	// {"status":"affirming","eat_profile":"tag:github.com/veraison/ar4si,2022-10-17","timestamp":"2022-09-26T17:29:00Z","appraisal-policy-id":"https://veraison.example/policy/1/60a0068d"}
+	// {"ear.status":"affirming","eat_profile":"tag:github.com/veraison/ar4si,2022-10-17","iat":1666091373,"ear.appraisal-policy-id":"https://veraison.example/policy/1/60a0068d"}
 }
 
 func Example_encode_hefty() {
@@ -40,7 +40,7 @@ func Example_encode_hefty() {
 			SourcedData:      2,
 		},
 		RawEvidence:       &rawEvidence,
-		Timestamp:         &testTimestamp,
+		IssuedAt:          &testIAT,
 		AppraisalPolicyID: &testPolicyID,
 		Profile:           &testProfile,
 	}
@@ -50,7 +50,7 @@ func Example_encode_hefty() {
 	fmt.Println(string(j))
 
 	// Output:
-	// {"status":"affirming","eat_profile":"tag:github.com/veraison/ar4si,2022-10-17","trust-vector":{"instance-identity":2,"configuration":2,"executables":3,"file-system":2,"hardware":2,"runtime-opaque":2,"storage-opaque":2,"sourced-data":2},"raw-evidence":"3q2+7w==","timestamp":"2022-09-26T17:29:00Z","appraisal-policy-id":"https://veraison.example/policy/1/60a0068d"}
+	// {"ear.status":"affirming","eat_profile":"tag:github.com/veraison/ar4si,2022-10-17","ear.trustworthiness-vector":{"instance-identity":2,"configuration":2,"executables":3,"file-system":2,"hardware":2,"runtime-opaque":2,"storage-opaque":2,"sourced-data":2},"ear.raw-evidence":"3q2+7w==","iat":1666091373,"ear.appraisal-policy-id":"https://veraison.example/policy/1/60a0068d"}
 }
 
 func Example_encode_veraison_extensions() {
@@ -61,14 +61,14 @@ func Example_encode_veraison_extensions() {
 	fmt.Println(string(j))
 
 	// Output:
-	// {"status":"affirming","eat_profile":"tag:github.com/veraison/ar4si,2022-10-17","timestamp":"2022-09-26T17:29:00Z","appraisal-policy-id":"https://veraison.example/policy/1/60a0068d","veraison.processed-evidence":{"k1":"v1","k2":"v2"},"veraison.verifier-added-claims":{"bar":"baz","foo":"bar"}}
+	// {"ear.status":"affirming","eat_profile":"tag:github.com/veraison/ar4si,2022-10-17","iat":1666091373,"ear.appraisal-policy-id":"https://veraison.example/policy/1/60a0068d","veraison.processed-evidence":{"k1":"v1","k2":"v2"},"veraison.verifier-added-claims":{"bar":"baz","foo":"bar"}}
 }
 
 func Example_decode_veraison_extensions() {
 	j := `{
-		"status": "affirming",
-		"timestamp": "2022-09-26T17:29:00Z",
-		"appraisal-policy-id": "https://veraison.example/policy/1/60a0068d",
+		"ear.status": "affirming",
+		"iat":1666091373,
+		"ear.appraisal-policy-id": "https://veraison.example/policy/1/60a0068d",
 		"veraison.processed-evidence": {
 			"k1": "v1",
 			"k2": "v2"
@@ -94,10 +94,10 @@ func Example_decode_veraison_extensions() {
 
 func Example_colors() {
 	j := `{
-		"status": "contraindicated",
-		"timestamp": "2022-09-26T17:29:00Z",
-		"appraisal-policy-id": "https://veraison.example/policy/1/60a0068d",
-		"trust-vector": {
+		"ear.status": "contraindicated",
+		"iat":1666091373,
+		"ear.appraisal-policy-id": "https://veraison.example/policy/1/60a0068d",
+		"ear.trustworthiness-vector": {
 			"instance-identity": 96,
 			"configuration": 96,
 			"executables": 32,


### PR DESCRIPTION
* segregate all newly defined claims under the `ear.` (EAT Attestation Result) namespace
* reuse JWT/CWT `iat` instead of `timestamp`

Fix #9

Signed-off-by: Thomas Fossati <thomas.fossati@arm.com>